### PR TITLE
Update connect-redirect.md

### DIFF
--- a/MicrosoftCollaboratePortal/connect-redirect.md
+++ b/MicrosoftCollaboratePortal/connect-redirect.md
@@ -56,12 +56,6 @@ The Office PIPC program is now hosted on [Microsoft Collaborate](https://aka.ms/
 ### Fast (Connect Site ID 898)
 The Fast program is now hosted on [Microsoft Collaborate](https://aka.ms/collaborate). If you have any questions about your program membership or access to Collaborate, please contact fastcsrv@microsoft.com.
 
-### WARP (Connect Site ID 1388)
-The WARP program is now hosted on [Microsoft Collaborate](https://aka.ms/collaborate). If you have any questions about your program membership or access to Collaborate, please contact warphelp@microsoft.com.
-
-### eWARP (Connect Site ID 1398)
-The eWARP program is now hosted on [Microsoft Collaborate](https://aka.ms/collaborate). If you have any questions about your program membership or access to Collaborate, please contact msews@microsoft.com.
-
 ### Microsoft Office (Connect Site ID 160)
 The Microsoft Office program is now hosted on [Microsoft Collaborate](https://aka.ms/collaborate). If you have any questions about your program membership or access to Collaborate, please contact officeconnectteam@microsoft.com.
 


### PR DESCRIPTION
From: Malcolm Dickson (MINDTREE LIMITED) 
Sent: Friday, September 7, 2018 12:07 PM
To: Tony Sampige <tsampige@microsoft.com>
Subject: Please remove WARP and eWARP on public facing Collaborate doc

Hi Tony,

Who should I reach out to in order to request removal of WARP and eWARP references on a public facing Collaborate doc (below)?

On https://docs.microsoft.com/en-us/collaborate/connect-redirect 

WARP (Connect Site ID 1388)
The WARP program is now hosted on Microsoft Collaborate. If you have any questions about your program membership or access to Collaborate, please contact warphelp@microsoft.com.
eWARP (Connect Site ID 1398)
The eWARP program is now hosted on Microsoft Collaborate. If you have any questions about your program membership or access to Collaborate, please contact msews@microsoft.com.

Thank you,

Malcolm Dickson
Program Manager | Studio E/1409
 

