### PR TITLE
Linkfix: Collaborate Portal (2021-06)

### DIFF
--- a/MicrosoftCollaboratePortal/CONTRIBUTING.md
+++ b/MicrosoftCollaboratePortal/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Thank you for your interest in our documentation. We appreciate your feedback, e
 > [!IMPORTANT]
 > All repositories that publish to docs.microsoft.com have adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any questions or comments.<br> 
 > 
-> Minor corrections or clarifications to documentation and code examples in public repositories are covered by the [docs.microsoft.com Terms of Use](https://docs.microsoft.com/legal/termsofuse). New or significant changes will generate a comment in the pull request asking you to submit an online Contribution License Agreement (CLA) if you are not an employee of Microsoft. We need you to complete the online form before we can accept your pull request.
+> Minor corrections or clarifications to documentation and code examples in public repositories are covered by the [docs.microsoft.com Terms of Use](/legal/termsofuse). New or significant changes will generate a comment in the pull request asking you to submit an online Contribution License Agreement (CLA) if you are not an employee of Microsoft. We need you to complete the online form before we can accept your pull request.
 
 ## How to make a change
 
@@ -26,13 +26,13 @@ Thank you for your interest in our documentation. We appreciate your feedback, e
 | 5. Click Preview changes to verify the formatting looks as expected. | ![Preview changes](images/edit-in-github.png)|
 | 6. When you're done, scroll to the bottom of the page and click "Propose file change", you will be presented with a "Comparing changes" page, allowing you to verify your changes. Then click the "Create pull request" button to submit your changes. At this point you are finished! | ![Propose a change](images/propose.jpg)|
 
-After you submit changes (via a pull request), they will be reviewed by a member of the documentation team. If your request is accepted, updates are published to [https://docs.microsoft.com/collaborate](https://docs.microsoft.com/collaborate).
+After you submit changes (via a pull request), they will be reviewed by a member of the documentation team. If your request is accepted, updates are published to [https://docs.microsoft.com/collaborate](/collaborate).
 
 *For internal review only, you can see your changes at [https://review.docs.microsoft.com/collaborateportal](https://review.docs.microsoft.com/en-us/collaborate/?branch=master).
 
 ## Working with Branches
 
-The [MS Collaborate GitHub repository](https://github.com/MicrosoftDocs/MicrosoftCollaboratePortal) utilizes two main parent branches: [Master](https://github.com/MicrosoftDocs/MicrosoftCollaboratePortal/tree/master), this content can be reviewed on the [staging site](https://review.docs.microsoft.com/collaborate), and [Live](https://github.com/MicrosoftDocs/MicrosoftCollaboratePortal/tree/live), for content appearing on the [live site](https://docs.microsoft.com/collaborate). 
+The [MS Collaborate GitHub repository](https://github.com/MicrosoftDocs/MicrosoftCollaboratePortal) utilizes two main parent branches: [Master](https://github.com/MicrosoftDocs/MicrosoftCollaboratePortal/tree/master), this content can be reviewed on the [staging site](https://review.docs.microsoft.com/collaborate), and [Live](https://github.com/MicrosoftDocs/MicrosoftCollaboratePortal/tree/live), for content appearing on the [live site](/collaborate). 
 
 When making contributions, please submit your Pull Request (PR) to the **Master** branch. This branch can be viewed on the staging site and should only contain contributions that are ready to be published live. You may also create and submit a branch with your own unique branch name which can be selected and viewed in the staging site. (The **Live** branch is only allowed for use by the content administrators.)
 

--- a/MicrosoftCollaboratePortal/CONTRIBUTING.md
+++ b/MicrosoftCollaboratePortal/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 ---
 title: Contribute to MS Collaborate documentation
-description: Covers the basic steps and guidelines for contributing to the documentation. 
+description: Covers the basic steps and guidelines for contributing to the documentation.
 author: ikhapova
 ms.author: ikhapova
 ms.date: 11/25/2019
@@ -11,8 +11,8 @@ ms.date: 11/25/2019
 Thank you for your interest in our documentation. We appreciate your feedback, edits, additions and help with improving our docs. This page covers the basic steps and guidelines for contributing.
 
 > [!IMPORTANT]
-> All repositories that publish to docs.microsoft.com have adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any questions or comments.<br> 
-> 
+> All repositories that publish to docs.microsoft.com have adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any questions or comments.<br>
+>
 > Minor corrections or clarifications to documentation and code examples in public repositories are covered by the [docs.microsoft.com Terms of Use](/legal/termsofuse). New or significant changes will generate a comment in the pull request asking you to submit an online Contribution License Agreement (CLA) if you are not an employee of Microsoft. We need you to complete the online form before we can accept your pull request.
 
 ## How to make a change
@@ -28,11 +28,11 @@ Thank you for your interest in our documentation. We appreciate your feedback, e
 
 After you submit changes (via a pull request), they will be reviewed by a member of the documentation team. If your request is accepted, updates are published to [https://docs.microsoft.com/collaborate](/collaborate).
 
-*For internal review only, you can see your changes at [https://review.docs.microsoft.com/collaborateportal](https://review.docs.microsoft.com/en-us/collaborate/?branch=master).
+*For internal review only, you can see your changes at [https://review.docs.microsoft.com/collaborateportal](https://review.docs.microsoft.com/collaborate/?branch=master).
 
 ## Working with Branches
 
-The [MS Collaborate GitHub repository](https://github.com/MicrosoftDocs/MicrosoftCollaboratePortal) utilizes two main parent branches: [Master](https://github.com/MicrosoftDocs/MicrosoftCollaboratePortal/tree/master), this content can be reviewed on the [staging site](https://review.docs.microsoft.com/collaborate), and [Live](https://github.com/MicrosoftDocs/MicrosoftCollaboratePortal/tree/live), for content appearing on the [live site](/collaborate). 
+The [MS Collaborate GitHub repository](https://github.com/MicrosoftDocs/MicrosoftCollaboratePortal) utilizes two main parent branches: [Master](https://github.com/MicrosoftDocs/MicrosoftCollaboratePortal/tree/master), this content can be reviewed on the [staging site](https://review.docs.microsoft.com/collaborate), and [Live](https://github.com/MicrosoftDocs/MicrosoftCollaboratePortal/tree/live), for content appearing on the [live site](/collaborate).
 
 When making contributions, please submit your Pull Request (PR) to the **Master** branch. This branch can be viewed on the staging site and should only contain contributions that are ready to be published live. You may also create and submit a branch with your own unique branch name which can be selected and viewed in the staging site. (The **Live** branch is only allowed for use by the content administrators.)
 

--- a/MicrosoftCollaboratePortal/connect-redirect.md
+++ b/MicrosoftCollaboratePortal/connect-redirect.md
@@ -53,7 +53,7 @@ Please contact the Microsoft Alumni Network program administrators for the statu
 Please contact [wmecert@microsoft.com](mailto:wmecert@microsoft.com) for the status of the program.
 
 ### High Performance Computing Team (Connect Site ID 12)
-Please visit https://partner.microsoft.com/en-us/solutions/practice-areas/cloud-infrastructure-management/high-performance-computing.
+Please visit https://partner.microsoft.com/solutions/practice-areas/cloud-infrastructure-management/high-performance-computing.
 
 ### DevDiv / Visual Studio and .NET Framework (Connect Site ID 210)
 
@@ -66,4 +66,4 @@ To report a new Visual Studio bug, please use the integrated Report a Problem fe
 Please contact [scrmteam@microsoft.com](mailto:scrmteam@microsoft.com) for the status of the program.
 
 ### Microsoft PlayReady Support
-Microsoft PlayReady Support for licensed companies is now provided by email. Please, send your questions to [AskDRM@microsoft.com](mailto:AskDRM@microsoft.com). In addition, please review documentation available at <https://docs.microsoft.com/playready> and [PlayReady Test Server](https://test.playready.microsoft.com/).
+Microsoft PlayReady Support for licensed companies is now provided by email. Please, send your questions to [AskDRM@microsoft.com](mailto:AskDRM@microsoft.com). In addition, please review documentation available at `https://docs.microsoft.com/playready` and [PlayReady Test Server](https://test.playready.microsoft.com/).

--- a/MicrosoftCollaboratePortal/connect-redirect.md
+++ b/MicrosoftCollaboratePortal/connect-redirect.md
@@ -18,7 +18,7 @@ Visit [Download Center](https://www.microsoft.com/download) if you are looking f
 
 ## Microsoft Docs
 
-[Microsoft Docs](https://docs.microsoft.com) is the home for Microsoft documentation for end users, developers, hardware manufacturers and IT professionals. Check out our quickstarts, tutorials, API reference, and code examples.
+[Microsoft Docs]() is the home for Microsoft documentation for end users, developers, hardware manufacturers and IT professionals. Check out our quickstarts, tutorials, API reference, and code examples.
 
 ## Where to Find Connect Programs
 

--- a/MicrosoftCollaboratePortal/feedback-items-overview.md
+++ b/MicrosoftCollaboratePortal/feedback-items-overview.md
@@ -27,7 +27,7 @@ In the MS Collaborate portal, each feedback work item is associated with a singl
 
 ## Legal Agreement 
 
-When you onboard to MS Collaborate, you accept the terms of use covering the feedback for the engagements you belong to. You can always review default terms here:  MS Collaborate [Terms of Use](https://go.microsoft.com/fwlink/?linkid=849107).
+When you onboard to MS Collaborate, you accept the terms of use covering the feedback for the engagements you belong to. You can always review default terms here:  MS Collaborate [Terms of Use](./terms-of-use.md).
 
 In collaboration engagements, a legal agreement must exist between the parties in order for them to collaborate. You may be asked to accept a legal agreement or terms of use before you access the engagement for the first time.  As a member of the engagement, you will be able to see the other organizations participating in the collaboration. Users can assign the bug to a specific organization to indicate the “partner on point.”  However, users will only see the names of other users in their organization.  Other organizations will not have access to the users list.
 
@@ -35,4 +35,4 @@ In collaboration engagements, a legal agreement must exist between the parties i
 
 The **Universal ID** is an ID provided by the MS Collaborate feedback system and is shared with all users who have access to the work item. This ID is the identifier within the MS Collaborate system and is not the specific identifier of any feature team engineering systems. This new **Universal ID** facilitates multi-party collaborations so there is one common identifier used by all parties.
 
-Your engagement owner may decide to also include additional fields showing the specific ID in the engineering system (for example, a VSTS ID). 
+Your engagement owner may decide to also include additional fields showing the specific ID in the engineering system (for example, a VSTS ID).

--- a/MicrosoftCollaboratePortal/feedback-items-overview.md
+++ b/MicrosoftCollaboratePortal/feedback-items-overview.md
@@ -1,17 +1,17 @@
 ---
 title: Working with Feedback work items
-description: Microsoft Collaborate Feedback items can be bugs, feature requests or any task associated with an engagement. Feedback forms can be customized based on each engagement. 
+description: Microsoft Collaborate Feedback items can be bugs, feature requests or any task associated with an engagement. Feedback forms can be customized based on each engagement.
 author: ikhapova
 ms.author: ikhapova
 ms.date: 12/12/2017
-keywords: feedback, engagements, work items, bugs, feature requests, Collaborate permissions, Microsoft Connect, SysDev Bug, Dev Center bugs 
+keywords: feedback, engagements, work items, bugs, feature requests, Collaborate permissions, Microsoft Connect, SysDev Bug, Dev Center bugs
 ---
 
-# Feedback
+# Working with Feedback work items
 
-## Overview 
+## Overview
 
-The [Feedback Hub](https://support.microsoft.com/en-us/help/4021566/windows-10-send-feedback-to-microsoft-with-feedback-hub-app) is a common mechanism for submitting bugs, issues and suggestions to Microsoft.  For organizations that are collaborating with Microsoft, MS Collaborate provides additional functionality that enables organizations and users to collaborate on feedback work items. Feedback can be configured in different ways to enable the functionality needed to support each specific collaboration.  
+The [Feedback Hub](https://support.microsoft.com/help/4021566/windows-10-send-feedback-to-microsoft-with-feedback-hub-app) is a common mechanism for submitting bugs, issues and suggestions to Microsoft.  For organizations that are collaborating with Microsoft, MS Collaborate provides additional functionality that enables organizations and users to collaborate on feedback work items. Feedback can be configured in different ways to enable the functionality needed to support each specific collaboration.
 
 The MS Collaborate Feedback "work items" are typically bugs and feature requests that you submit to Microsoft, but the work items can be any kind of data that can be shared in a form (such as surveys, incidents, etc.). Each MS Collaborate Engagement Owner defines the feedback forms and how the data is synced to an internal Microsoft team engineering system (such as VSTS). Engagement Owners also configure routing to internal systems to ensure your feedback gets to the right feature teams.
 
@@ -19,13 +19,13 @@ In addition to using the MS Collaborate portal, some co-engineering partner orga
 
 In the MS Collaborate portal, each feedback work item is associated with a single engagement to ensure only the right users and systems have access to the work item. Engagements can be between a Microsoft organization and one other organization (a single organization engagement) or the engagement can be between multiple organizations (multi-party engagements) - for example, a Microsoft organization plus an OEM, an ODM, and an IHV partner working on a specific device.  For more information on engagements, see [Programs and Engagements](intro-to-mscollaborate.md#programs-and-engagements).
 
-- In **single-party engagements**, only the specific Microsoft organization and the one named organization can see the feedback work item(s) associated with the engagement. Both organization users can create new and collaborate on existing work items in the engagement. No other organizations or users not associated with the engagement can see the work item. 
+- In **single-party engagements**, only the specific Microsoft organization and the one named organization can see the feedback work item(s) associated with the engagement. Both organization users can create new and collaborate on existing work items in the engagement. No other organizations or users not associated with the engagement can see the work item.
 
 - In **multi-party engagements**, all organizations named in the engagement can see and edit the same shared work item(s).  No other organizations or users not associated with the engagement can see the work item.
 
-- In **any organization engagements**, users are added as individuals and not as organizations. This engagement style is typically used for incoming feedback only.   
+- In **any organization engagements**, users are added as individuals and not as organizations. This engagement style is typically used for incoming feedback only.
 
-## Legal Agreement 
+## Legal Agreement
 
 When you onboard to MS Collaborate, you accept the terms of use covering the feedback for the engagements you belong to. You can always review default terms here:  MS Collaborate [Terms of Use](./terms-of-use.md).
 

--- a/MicrosoftCollaboratePortal/feedback-items-remove-personal-data.md
+++ b/MicrosoftCollaboratePortal/feedback-items-remove-personal-data.md
@@ -42,4 +42,4 @@ More information on GDPR is available at [Microsoft.com/GDPR](https://Microsoft.
 ## How to leave an organization as a guest user
 
 A user, who previously accepted **invitation** from an organization to partcipate in Collaborate, can decide to leave organization at any time if access is no longer needed. A user can leave an organization on their own, without having to contact an administrator.
-See [Leave an Organization](https://docs.microsoft.com/azure/active-directory/b2b/leave-the-organization#leave-an-organization) for detailed instructions.
+See [Leave an Organization](/azure/active-directory/b2b/leave-the-organization#leave-an-organization) for detailed instructions.

--- a/MicrosoftCollaboratePortal/feedback-items.md
+++ b/MicrosoftCollaboratePortal/feedback-items.md
@@ -1,16 +1,17 @@
 ---
-title: Working with Feedback work items
-description: Microsoft Collaborate Feedback items can be bugs, feature requests or any task associated with an engagement. Feedback forms can be customized based on each engagement. 
+title: Working with Microsoft Collaborate Feedback work items
+description: Microsoft Collaborate Feedback items can be bugs, feature requests or any task associated with an engagement. Feedback forms can be customized based on each engagement.
 author: ikhapova
 ms.author: ikhapova
 ms.date: 12/12/2017
-keywords: feedback, engagements, work items, bugs, feature requests, Collaborate permissions, Microsoft Connect, SysDev Bug, Dev Center bugs 
+keywords: feedback, engagements, work items, bugs, feature requests, Collaborate permissions, Microsoft Connect, SysDev Bug, Dev Center bugs
 ---
 
-# Feedback
+# Working with Microsoft Collaborate Feedback work items
 
 ## Overview
-The [Feedback Hub](https://support.microsoft.com/en-us/help/4021566/windows-10-send-feedback-to-microsoft-with-feedback-hub-app) is a common mechanism for submitting bugs, issues and suggestions to Microsoft.  For organizations that are collaborating with Microsoft, MS Collaborate provides additional functionality that enables organizations and users to collaborate on feedback work items. Feedback can be configured in different ways to enable the functionality needed to support each specific collaboration.  
+
+The [Feedback Hub](https://support.microsoft.com/en-us/help/4021566/windows-10-send-feedback-to-microsoft-with-feedback-hub-app) is a common mechanism for submitting bugs, issues and suggestions to Microsoft.  For organizations that are collaborating with Microsoft, MS Collaborate provides additional functionality that enables organizations and users to collaborate on feedback work items. Feedback can be configured in different ways to enable the functionality needed to support each specific collaboration.
 
 The MS Collaborate Feedback "work items" are typically bugs and feature requests that you submit to Microsoft, but the work items can be any kind of data that can be shared in a form (such as surveys, incidents, etc.). Each MS Collaborate Engagement Owner defines the feedback forms and how the data is synced to an internal Microsoft team engineering system (such as VSTS). Engagement Owners also configure routing to internal systems to ensure your feedback gets to the right feature teams.
 
@@ -20,13 +21,13 @@ In addition to using the MS Collaborate portal, some co-engineering partner orga
 
 In the MS Collaborate portal, each feedback work item is associated with a single engagement to ensure only the right users and systems have access to the work item. Engagements can be between a Microsoft organization and one other organization (a single organization engagement) or the engagement can be between multiple organizations (multi-party engagements) - for example, a Microsoft organization plus an OEM, an ODM, and an IHV partner working on a specific device.  For more information on engagements, see [Programs and Engagements](intro-to-mscollaborate.md#programs-and-engagements).
 
-- In **single-party engagements**, only the specific Microsoft organization and the one named organization can see the feedback work item(s) associated with the engagement. Both organization users can create new and collaborate on existing work items in the engagement. No other organizations or users not associated with the engagement can see the work item. 
+- In **single-party engagements**, only the specific Microsoft organization and the one named organization can see the feedback work item(s) associated with the engagement. Both organization users can create new and collaborate on existing work items in the engagement. No other organizations or users not associated with the engagement can see the work item.
 
 - In **multi-party engagements**, all organizations named in the engagement can see and edit the same shared work item(s).  No other organizations or users not associated with the engagement can see the work item.
 
-- In **any organization engagements**, users are added as individuals and not as organizations. This engagement style is typically used for incoming feedback only.   
+- In **any organization engagements**, users are added as individuals and not as organizations. This engagement style is typically used for incoming feedback only.
 
-## Legal Agreement 
+## Legal Agreement
 
 When you onboard to MS Collaborate, you accept the terms of use covering the feedback for the engagements you belong to. You can always review default terms here:  MS Collaborate [Terms of Use](./terms-of-use.md).
 

--- a/MicrosoftCollaboratePortal/feedback-items.md
+++ b/MicrosoftCollaboratePortal/feedback-items.md
@@ -28,7 +28,7 @@ In the MS Collaborate portal, each feedback work item is associated with a singl
 
 ## Legal Agreement 
 
-When you onboard to MS Collaborate, you accept the terms of use covering the feedback for the engagements you belong to. You can always review default terms here:  MS Collaborate [Terms of Use](https://go.microsoft.com/fwlink/?linkid=849107).
+When you onboard to MS Collaborate, you accept the terms of use covering the feedback for the engagements you belong to. You can always review default terms here:  MS Collaborate [Terms of Use](./terms-of-use.md).
 
 In collaboration engagements, a legal agreement must exist between the parties in order for them to collaborate. You may be asked to accept a legal agreement or terms of use before you access the engagement for the first time.  As a member of the engagement, you will be able to see the other organizations participating in the collaboration. Users can assign the bug to a specific organization to indicate the “partner on point.”  However, users will only see the names of other users in their organization.  Other organizations will not have access to the users list.
 
@@ -36,4 +36,4 @@ In collaboration engagements, a legal agreement must exist between the parties i
 
 The Universal Partner ID is an ID provided by the MS Collaborate feedback system and is shared with all users who have access to the work item. This ID is the ID within the MS Collaborate system and is not the specific ID of any feature team engineering system. This new universal ID facilitates multi-party collaborations so there is one common ID used by all parties.
 
-> Engagement owner(s) may decide to also include additional fields showing the specific ID in the engineering system (for example, a VSTS ID). 
+> Engagement owner(s) may decide to also include additional fields showing the specific ID in the engineering system (for example, a VSTS ID).

--- a/MicrosoftCollaboratePortal/index.yml
+++ b/MicrosoftCollaboratePortal/index.yml
@@ -23,18 +23,18 @@ landingContent:
       - linkListType: overview
         links:
           - text: Introduction
-            url: /collaborate/intro-to-mscollaborate
+            url: ./intro-to-mscollaborate.md
       - linkListType: how-to-guide
         links:
           - text: Registration
-            url: /collaborate/registration
+            url: ./registration.md
           - text: Access Management
-            url: /collaborate/managing-org-users
+            url: ./managing-org-users.md
           - text: Programs and Engagements
-            url: /collaborate/programs
+            url: ./programs.md
           - text: Package downloads
-            url: /collaborate/package-downloads
+            url: ./package-downloads.md
       - linkListType: reference
         links:
           - text: Feedback
-            url: /collaborate/feedback-items
+            url: ./feedback-items.md

--- a/MicrosoftCollaboratePortal/intro-to-mscollaborate.md
+++ b/MicrosoftCollaboratePortal/intro-to-mscollaborate.md
@@ -43,7 +43,7 @@ Engagements are similar to a virtual security group, allowing engagement owners 
 - collaboration between multiple named organizations (e.g., Microsoft team 1 users, company A users, and company B users), and
 - collaboration with users from any organizations.
 
-Each engagement is associated with either the default MS Collaborate [Terms of Use](https://go.microsoft.com/fwlink/?linkid=849107) or an appropriate custom legal agreement between the parties in the engagement. Participant users should visit the engagement page and see the description and agreement that applies to each specific engagement.  For more information about seeing the legal agreement for an engagement, see [How to view your Engagements](view-engagements.md).
+Each engagement is associated with either the default MS Collaborate [Terms of Use](./terms-of-use.md) or an appropriate custom legal agreement between the parties in the engagement. Participant users should visit the engagement page and see the description and agreement that applies to each specific engagement.  For more information about seeing the legal agreement for an engagement, see [How to view your Engagements](view-engagements.md).
 
 Engagement owners are Microsoft users who manage the engagement in MS Collaborate.  Users with Engagement Owner permissions can: 
 - create new collaborations in the system as a named engagement that will map content or feedback to users, 
@@ -124,4 +124,3 @@ When migrating from MS Connect to MS Collaborate, it is important to understand 
 - Program and engagement names are visible to all users.  Engagements with defined organiations or companies clearly identify the organizations who have permissions for the engagement on the engagement page.  The legal agreement for the engagement is also available to all users who are members of the engagement.
 
 When migrating from the older system to the new Partner Center-based MS Collaborate, the biggest change is migrating user accounts to Partner Center.  Partner Center identifies a "Partner Center Admin" who is responsible for managing the Partner Center accounts for the company.  You will need to know who your admin is and whether your company uses Active Directory or not.  
-   

--- a/MicrosoftCollaboratePortal/managing-org-users.md
+++ b/MicrosoftCollaboratePortal/managing-org-users.md
@@ -1,6 +1,6 @@
 ---
 title: Access Management
-description: Microsoft Collaborate enables users from organizations to control the adding/removing of users for the organization.  During onboarding, Engagement Owners can assign individuals from an organization Power User permissions.  Power Users can only manage their own organization’s users. 
+description: Microsoft Collaborate enables users from organizations to control the adding/removing of users for the organization.  During onboarding, Engagement Owners can assign individuals from an organization Power User permissions.  Power Users can only manage their own organization’s users.
 author: ikhapova
 ms.author: ikhapova
 ms.date: 12/12/2017
@@ -9,9 +9,9 @@ keywords: engagements, adding users, removing users, managing users, Collaborate
 
 # Access Management
 
-## Overview 
+## Overview
 
-What a user can do within the portal is defined by the *engagements* and *groups* they belong to. If user is a *participant*, they can see the engagement metadata, content and feedback associated with the engagement. Additional permissions can be granted through other groups. 
+What a user can do within the portal is defined by the *engagements* and *groups* they belong to. If user is a *participant*, they can see the engagement metadata, content and feedback associated with the engagement. Additional permissions can be granted through other groups.
 
 At this time, only Microsoft users can manage programs and engagements. Partners and customers can participate in the existing engagements and manage user access for their organization.
 
@@ -26,13 +26,14 @@ The following groups exist in the portal:
 | Power User | Engagement | Advanced users who manage access for their organization | Add and remove participants for their organization |
 | Content Publisher | Engagement | Microsoft users who publish content | Publish content |
 | Engagement Owner | Engagement | Microsoft users who manage existing engagements | Manage all aspects of the engagement |
-| Engagement Manager | Program  | Microsoft users who create new engagements | Create new engagements under specific program | 
-| Program Owner | Program | Microsoft users who manage programs | Manage all aspects of the program and all engagements under the program | 
+| Engagement Manager | Program  | Microsoft users who create new engagements | Create new engagements under specific program |
+| Program Owner | Program | Microsoft users who manage programs | Manage all aspects of the program and all engagements under the program |
 
 ## Discovering available engagements
 
 **New users**
-* Click on the [Join engagements](https://partner.microsoft.com/en-us/dashboard/collaborate/engagements/discover) link on the dashboard to browse the list of *new* engagements available to you and your organization.
+
+* Click on the [Join engagements](https://partner.microsoft.com/dashboard/collaborate/engagements/discover) link on the dashboard to browse the list of *new* engagements available to you and your organization.
 
 **Existing users**
 * Navigate to the [engagements](https://partner.microsoft.com/en-us/dashboard/collaborate/engagements) list and click **Join** button to view available engagements.
@@ -42,17 +43,17 @@ The following groups exist in the portal:
 In order to download content or submit feedback you need to become a participant. Depending on how engagement is configured, you can:
 * Join
 * Request access
-* Contact engagement administrators (users with **Engagement Owner** or **Power User** role) using other channels, for example e-mail, and ask them to add you to the engagement.  
+* Contact engagement administrators (users with **Engagement Owner** or **Power User** role) using other channels, for example e-mail, and ask them to add you to the engagement.
 
 > [!TIP]
-> **Power User** is a representative from your organization who manages engagement access.  
+> **Power User** is a representative from your organization who manages engagement access.
 > Depending on how engagement is configured, owner approval might be required for users to join. Some engagements only require acceptance of terms of use.
 
 ### Join
 
 1. Find the engagement you are interested in and click on its name. Page with detailed engagement information will open.
-2. Review *Description* and *Terms of use* to make sure you understand engagement purpose and terms of use. 
-3. Check *I accept Terms of Use* field. 
+2. Review *Description* and *Terms of use* to make sure you understand engagement purpose and terms of use.
+3. Check *I accept Terms of Use* field.
 4. Click **Join** button.
 
 ![Join](images/Join-2.PNG)
@@ -62,7 +63,7 @@ Engagement will be added to the engagement list and you can start using it. If y
 ### Request access
 
 1. Find the engagement you are interested in and click on its name. Page with detailed engagement information will open.
-2. Review *Description* and *Terms of use* to make sure you understand engagement purpose and terms of use. 
+2. Review *Description* and *Terms of use* to make sure you understand engagement purpose and terms of use.
 3. Check *I accept Terms of Use* field.
 4. Provide justification for requesting access.
 5. Click **Request Access** button.
@@ -73,28 +74,28 @@ Administrators (users in *Engagement owner* and *Power User* groups) will be not
 
 ## Managing users
 
-Only users that exist in a Partner Center account can be added to engagements. If a company or an organization does not have an account in Partner Center, their representative needs to create an account and identify an organization admin who can add other users. 
+Only users that exist in a Partner Center account can be added to engagements. If a company or an organization does not have an account in Partner Center, their representative needs to create an account and identify an organization admin who can add other users.
 
 See [Register with Microsoft Collaborate](registration.md) for more information about creating an account in Partner Center.
 
 > [!NOTE]
-> Collaborate uses the same account as other programs in Partner Center.  The type of account you choose is important if your company or organization plans to enroll in other Partner Center programs that require bank account or certificate information.  
-> 
+> Collaborate uses the same account as other programs in Partner Center.  The type of account you choose is important if your company or organization plans to enroll in other Partner Center programs that require bank account or certificate information.
+>
 > If your organization uses Azure Active Directory (AAD), you need to add users from AAD tenant to the Partner Center account before they can join an engagement.
-> 
-> If you belong to multiple Partner Center accounts, be sure to use Collaborate with the one your organization used for Collaborate onboarding.  
+>
+> If you belong to multiple Partner Center accounts, be sure to use Collaborate with the one your organization used for Collaborate onboarding.
 
 ### How to add a participant
 
-Once a user is added to a Partner Center account, *Power User(s)* delegated by the organization can add them to engagements. *Power User(s)* can only manage *Participant(s)* group for their organization. *Power User(s)* cannot add or remove other *Power User(s)*. 
+Once a user is added to a Partner Center account, *Power User(s)* delegated by the organization can add them to engagements. *Power User(s)* can only manage *Participant(s)* group for their organization. *Power User(s)* cannot add or remove other *Power User(s)*.
 
-1. Find the engagement you want to add participant to and click **Manage Membership**. 
+1. Find the engagement you want to add participant to and click **Manage Membership**.
 
 2. Click on the **Membership** tab and select the *Participant* group.
 
 	![Select a Group](images/Membership-tab.PNG)
 
-3. Click the **Add** button under **Members (Participant)**. 
+3. Click the **Add** button under **Members (Participant)**.
 
 4. Search dialog will open. Enter name of the user or e-mail address click **Search** button. You can also search using partial match.
 
@@ -108,29 +109,30 @@ Once added to the *Participant* group, users can download content and submit fee
 
 ### How to remove a participant
 
-1. To remove a user, select their name in the list and click the delete ![Delete](images/Delete.PNG) icon.
- 
+1. To remove a user, select their name in the list and click the delete ![Delete user](images/Delete.PNG) icon.
+
 2. Confirm that you want to remove the user, and they will no longer be a member of the group.
 
 Note that removing a user from an engagement does not impact the user's account in the Partner Center account system.  The user account will remain available for other engagements and other Partner Center programs.
 
 ### How to add a power user
 
-Only *Engagement Owners* can add *Power Users* for an organization. Reach out to your Microsoft contact to inform them who will manage access for your organization and they will add them to the *Power User* group. 
+Only *Engagement Owners* can add *Power Users* for an organization. Reach out to your Microsoft contact to inform them who will manage access for your organization and they will add them to the *Power User* group.
 
 ### If a user is missing from search results
 
-An organization's *Power Users* can only search for users within their own organization's Partner Center account. 
+An organization's *Power Users* can only search for users within their own organization's Partner Center account.
 
 If a user does not appear in search results:
+
 - verify if they are added to the organization’s account in Partner Center. If not, work with the **Administrator** of your organization account to add missing users. See [Add users to your Partner Center account](/windows/uwp/publish/add-users-groups-and-azure-ad-applications#add-users-to-your-dev-center-account) article for the detailed instructions.
 - It is possible that the organization has more than one Partner Center organization account (seller ID) in Partner Center. Verify that correct organization is used. If incorrect organization is used, reach out to your Microsoft contact.
-	
+
 ### How to export list of participants to a file
 
 1. Select the *Participant* group.
 
-2. Click **Export** button. 
+2. Click **Export** button.
 
 3. Save the file to local disk.
 
@@ -138,7 +140,7 @@ If a user does not appear in search results:
 
 1. Select the *Participant* group.
 
-2. Click **Copy** button. 
+2. Click **Copy** button.
 
 3. Type name of the engagement you want to copy users from and click **Search** button.
 

--- a/MicrosoftCollaboratePortal/managing-org-users.md
+++ b/MicrosoftCollaboratePortal/managing-org-users.md
@@ -123,7 +123,7 @@ Only *Engagement Owners* can add *Power Users* for an organization. Reach out to
 An organization's *Power Users* can only search for users within their own organization's Partner Center account. 
 
 If a user does not appear in search results:
-- verify if they are added to the organization’s account in Partner Center. If not, work with the **Administrator** of your organization account to add missing users. See [Add users to your Partner Center account](https://docs.microsoft.com/windows/uwp/publish/add-users-groups-and-azure-ad-applications#add-users-to-your-dev-center-account) article for the detailed instructions.
+- verify if they are added to the organization’s account in Partner Center. If not, work with the **Administrator** of your organization account to add missing users. See [Add users to your Partner Center account](/windows/uwp/publish/add-users-groups-and-azure-ad-applications#add-users-to-your-dev-center-account) article for the detailed instructions.
 - It is possible that the organization has more than one Partner Center organization account (seller ID) in Partner Center. Verify that correct organization is used. If incorrect organization is used, reach out to your Microsoft contact.
 	
 ### How to export list of participants to a file
@@ -143,7 +143,3 @@ If a user does not appear in search results:
 3. Type name of the engagement you want to copy users from and click **Search** button.
 
 4. Select users from the list and click **Add Users** button.
-
-
-
-

--- a/MicrosoftCollaboratePortal/managing-org-users.md
+++ b/MicrosoftCollaboratePortal/managing-org-users.md
@@ -36,7 +36,8 @@ The following groups exist in the portal:
 * Click on the [Join engagements](https://partner.microsoft.com/dashboard/collaborate/engagements/discover) link on the dashboard to browse the list of *new* engagements available to you and your organization.
 
 **Existing users**
-* Navigate to the [engagements](https://partner.microsoft.com/en-us/dashboard/collaborate/engagements) list and click **Join** button to view available engagements.
+
+* Navigate to the [engagements](https://partner.microsoft.com/dashboard/collaborate/engagements) list and click **Join** button to view available engagements.
 
 ![Available engagements](images/Join.PNG)
 

--- a/MicrosoftCollaboratePortal/registration.md
+++ b/MicrosoftCollaboratePortal/registration.md
@@ -20,9 +20,9 @@ Microsoft Collaborate program is offered through Partner Center and requires reg
  
 ## How to register as an individual
 
-1. Navigate to the [Partner Center Directory](https://partner.microsoft.com/en-us/dashboard/directory).
+1. Navigate to the [Partner Center Directory](https://partner.microsoft.com/dashboard/directory).
 2. If you're not already signed, sign in now using existing account or create new *Microsoft Account*. 
-3. Scroll down to **Developer programs** section and click on [Get Started](https://partner.microsoft.com/en-us/dashboard/registration/collaborate) link for **Microsoft Collaborate**. 
+3. Scroll down to **Developer programs** section and click on [Get Started](https://partner.microsoft.com/dashboard/registration/collaborate) link for **Microsoft Collaborate**. 
 
    ![Get Started](images/PartnerCenterDirectory.png)
 

--- a/MicrosoftCollaboratePortal/registration.md
+++ b/MicrosoftCollaboratePortal/registration.md
@@ -53,7 +53,7 @@ Microsoft Collaborate program is offered through Partner Center and requires reg
 
    If you are registering as a company, you'll also need to enter the name, email address, and phone number of the person who will approve your company's account.
 
-9. Review your account info and confirm that everything is correct. Then, read and accept the terms and conditions of the [Collaborate Agreement](https://go.microsoft.com/fwlink/?linkid=849107). Check the box to indicate you have read and accepted these terms.
+9. Review your account info and confirm that everything is correct. Then, read and accept the terms and conditions of the [Collaborate Agreement](./terms-of-use.md). Check the box to indicate you have read and accepted these terms.
 
 10. Click **Finish** to confirm your registration.  
 

--- a/MicrosoftCollaboratePortal/support.md
+++ b/MicrosoftCollaboratePortal/support.md
@@ -11,9 +11,9 @@ keywords: support, troubleshooting
 This page provides instructions on how to get support with Microsoft Collaborate.
 
 ## Support Options
-1. If you are not sure how to do something in Microsoft Collaborate, review the [Documentation and Guidance](https://docs.microsoft.com/collaborate/) for the area you have questions about.
+1. If you are not sure how to do something in Microsoft Collaborate, review the [Documentation and Guidance](./index.yml) for the area you have questions about.
 2. If your question or issue is related to a specific program or engagement, check their support options first. This information is available on the program and engagement overview pages respectively.
-3. If something is not working the way you expect, check the [Troubleshooting Guides](https://docs.microsoft.com/collaborate/troubleshooting) to see if your issue is described.
+3. If something is not working the way you expect, check the [Troubleshooting Guides](./troubleshooting.md) to see if your issue is described.
 4. If none of the above answers your question or resolves your issue, contact [Customer Support](https://support.microsoft.com/supportrequestform/83cdfd8d-c24a-fbe4-fb2a-3fead30613a9). 
 
 ## Customer Support
@@ -37,5 +37,4 @@ This page provides instructions on how to get support with Microsoft Collaborate
  
 <br>
 
-![Customer Support](images/customer-support.png) 
-
+![Customer Support](images/customer-support.png)

--- a/MicrosoftCollaboratePortal/troubleshooting.md
+++ b/MicrosoftCollaboratePortal/troubleshooting.md
@@ -8,36 +8,43 @@ keywords: troubeshooting, issues, registration, access, accounts, feedback
 ---
 
 # How to Troubleshoot Common Issues
+
 This page provides troubleshooting guides for common issues.
 
 ## Sign-in
 
 ### Browser shows "Resources for partners" page when signing in to Partner Center
+
 After navigating to Collaborate dashboard and entering your username and password, you are being redirected to [Resources for partners](https://partner.microsoft.com/en-us/dashboard/directory) page.
 
 #### Fixes/Workarounds
 
 ##### Change Directory / Account
+
 - click on the badge icon in the upper right corner and select the directory you usually work in
 - use account selection control in the left navigation menu to select correct account
 
 ##### Clear browsing cache in EDGE
+
 - Open **Settings and more** menu
 - Select **Settings**, then **Privacy and security**
 - Click on **Choose what to clear** button under **Clear browsing data** section
 - Select **Cookies and saved website data** and **Cached data and files** options
 - Click **Clear** button.
 
-Read more about [browser cache](https://support.microsoft.com/en-us/help/10607/microsoft-edge-view-delete-browser-history).
+Read more about [browser cache](https://support.microsoft.com/help/10607/microsoft-edge-view-delete-browser-history).
 
 ##### Clear browsing cache in Chrome
+
 - Open **Customize and control Google Chrome** menu
 - Select **More tools**, then **Clear browsing data...**
 - Select **Cookies and other site data** and **Cached images and files** options
 - Click **Clear data** button.
 
 ### Microsoft Account Sign-in
-If you can't sign in to Microsoft Collaborate website, try these suggestions: 
+
+If you can't sign in to Microsoft Collaborate website, try these suggestions:
+
 - make sure that you sign in using your complete email address
 - check the status of the Microsoft account service
 - make sure that you entered your password correctly. Passwords are case sensitive. If you've forgotten your password, go to the Microsoft account [reset your password](https://account.live.com/password/reset) page.
@@ -45,7 +52,9 @@ If you can't sign in to Microsoft Collaborate website, try these suggestions:
 - try clearing your browser's cache, cookies, temporary files, and any other browsing history that is stored. Close your browser, then open a new InPrivate browsing session.
 
 ### Browser hangs or shows "page can't be displayed" error when signing in to Partner Center
+
 After navigating to Collaborate dashboard and entering your username and password, you see one of these issues or errors:
+
 - your browser appears to hang or become unresponsive
 - you get a "page can't be displayed" error
 - you get an error that says "ERR_TOO_MANY_REDIRECTS"
@@ -57,9 +66,11 @@ After navigating to Collaborate dashboard and entering your username and passwor
 > Please contact your admin to ensure you are properly configured in your on-premises AD and you can re-attempt to accept this invite.
 
 #### Why this is happening
+
 There is a good chance this is happening because your corporate email address is linked to a personal MSA/Live ID (work and personal accounts share the same name), which was a common practice with Microsoft Connect accounts. This practice is no longer supported by Microsoft and could lead to various issues. Please see [this blog post](https://cloudblogs.microsoft.com/enterprisemobility/2016/09/15/cleaning-up-the-azure-ad-and-microsoft-account-overlap/) for more details.
 
 #### Fixes/Workarounds
+
 The workaround is to rename your personal MSA account. See [this article](https://support.microsoft.com/en-us/help/11545/microsoft-account-rename-your-personal-account) for the detailed steps.
 
 ## Registration
@@ -73,9 +84,11 @@ The workaround is to rename your personal MSA account. See [this article](https:
 The error indicates that a user is signed in with a work account (AAD) that does not have administrator privileges. 
 
 #### Fixes/Workarounds
+
 Follow the [instructions](./registration.md) to register using Microsoft Account.
 
 #### How to find Global Administrator for your Organization
+
 Finding **Global Administrator** can be be a difficult task, especially if organization is big and offices are located in multiple countries. 
 
 ##### Using **Azure Portal**:
@@ -93,6 +106,7 @@ Finding **Global Administrator** can be be a difficult task, especially if organ
 ![Roles and Administrators](images/aad-global-admin.png)
 
 Check out these articles to learn more about **Global Administrator** role.
+
 * [Understanding Azure identity solutions](/azure/active-directory/fundamentals/understand-azure-identity-solutions#terms-to-know)
 * [View members and descriptions of administrator roles in Azure Active Directory](/azure/active-directory/users-groups-roles/directory-manage-roles-portal)
 
@@ -122,6 +136,7 @@ Check out these articles to learn more about **PowerShell** and **Azure AD Modul
 ](/powershell/azure/active-directory/install-adv2?view=azureadps-2.0#installing-the-azure-ad-module)
 
 ### Invitations
+
 If you have been invited to join Partner Center account, you need to accept the invitation before you can access Collaborate portal. If you see an error message similar to shown below, it means that you have two accounts with Microsoft using the same email address. 
 
 > You have been invited to access ... application as ... .<br> 
@@ -146,15 +161,19 @@ Once completed proceed with accepting the Collaborate invitations that are send 
 ## Access
 
 ### User cannot see packages and/or engagements he/she has access to
+
 Most users belong to a single AAD tenant and single account within DevCenter. Users, that exist in several AAD tenants and/or accounts in DevCenter, might need to manually select specific AAD tenant and/or account to get access to resources.
 
 #### How to select an AAD tenant
+
 Click on the badge icon in the upper right corner of the screen. You will see a list of available AAD tenants if you exist in more than one AAD tenant. 
 
 #### How to select specific account for an AAD tenant
+
 Account name is shown in the left navigation pane above list of programs available for this account. Click on the currently displayed account name to open a list of available accounts for the selected AAD tenant.
 
 ## Distribution Manager
+
 You may receive an error message when you use Distribution Manager. This article contains information to help you troubleshoot these  error messages.
 
 ### Cannot Install Application
@@ -173,6 +192,7 @@ Click on the link to install [Microsoft .NET Framework 4.6.1 (x86/x64)](https://
 You may receive this error if you recently upgraded from an older version of the application.
 
 #### Fixes/Workarounds
+
 The workaround is to delete the click-once application data.
 
 
@@ -191,7 +211,7 @@ The exact path can be determined by the following steps:
 5. Now go to the Data path (%LOCALAPPDATA%\Apps\2.0\Data), and search for a folder with the same name 
    > dist..tion_xxxxxxxxxxxxxxxx_0000.0000_xxxxxxxxxxxxxxxx\Data
 
-![Distribution Manager folder](images/DistributionManagerDataLocation.png)
+![Distribution Manager Data folder](images/DistributionManagerDataLocation.png)
 
 6. Delete content of the folder
 7. Restart the application

--- a/MicrosoftCollaboratePortal/troubleshooting.md
+++ b/MicrosoftCollaboratePortal/troubleshooting.md
@@ -15,7 +15,7 @@ This page provides troubleshooting guides for common issues.
 
 ### Browser shows "Resources for partners" page when signing in to Partner Center
 
-After navigating to Collaborate dashboard and entering your username and password, you are being redirected to [Resources for partners](https://partner.microsoft.com/en-us/dashboard/directory) page.
+After navigating to Collaborate dashboard and entering your username and password, you are being redirected to [Resources for partners](https://partner.microsoft.com/dashboard/directory) page.
 
 #### Fixes/Workarounds
 
@@ -71,7 +71,7 @@ There is a good chance this is happening because your corporate email address is
 
 #### Fixes/Workarounds
 
-The workaround is to rename your personal MSA account. See [this article](https://support.microsoft.com/en-us/help/11545/microsoft-account-rename-your-personal-account) for the detailed steps.
+The workaround is to rename your personal MSA account. See [this article](https://support.microsoft.com/help/11545/microsoft-account-rename-your-personal-account) for the detailed steps.
 
 ## Registration
 
@@ -81,7 +81,7 @@ The workaround is to rename your personal MSA account. See [this article](https:
 
 ![We could not validate your identity as a global administrator](images/GlobalAdministrator.png)
 
-The error indicates that a user is signed in with a work account (AAD) that does not have administrator privileges. 
+The error indicates that a user is signed in with a work account (AAD) that does not have administrator privileges.
 
 #### Fixes/Workarounds
 

--- a/MicrosoftCollaboratePortal/troubleshooting.md
+++ b/MicrosoftCollaboratePortal/troubleshooting.md
@@ -73,7 +73,7 @@ The workaround is to rename your personal MSA account. See [this article](https:
 The error indicates that a user is signed in with a work account (AAD) that does not have administrator privileges. 
 
 #### Fixes/Workarounds
-Follow the [instructions](https://docs.microsoft.com/collaborate/registration) to register using Microsoft Account.
+Follow the [instructions](./registration.md) to register using Microsoft Account.
 
 #### How to find Global Administrator for your Organization
 Finding **Global Administrator** can be be a difficult task, especially if organization is big and offices are located in multiple countries. 
@@ -93,8 +93,8 @@ Finding **Global Administrator** can be be a difficult task, especially if organ
 ![Roles and Administrators](images/aad-global-admin.png)
 
 Check out these articles to learn more about **Global Administrator** role.
-* [Understanding Azure identity solutions](https://docs.microsoft.com/azure/active-directory/fundamentals/understand-azure-identity-solutions#terms-to-know)
-* [View members and descriptions of administrator roles in Azure Active Directory](https://docs.microsoft.com/azure/active-directory/users-groups-roles/directory-manage-roles-portal)
+* [Understanding Azure identity solutions](/azure/active-directory/fundamentals/understand-azure-identity-solutions#terms-to-know)
+* [View members and descriptions of administrator roles in Azure Active Directory](/azure/active-directory/users-groups-roles/directory-manage-roles-portal)
 
 ##### Using PowerShell
 
@@ -117,9 +117,9 @@ Check out these articles to learn more about **Global Administrator** role.
 ```
 
 Check out these articles to learn more about **PowerShell** and **Azure AD Module**.
-* [Installing Windows PowerShell](https://docs.microsoft.com/powershell/scripting/setup/installing-windows-powershell?view=powershell-6)
+* [Installing Windows PowerShell](/powershell/scripting/setup/installing-windows-powershell?view=powershell-6)
 * [Installing the Azure AD Module
-](https://docs.microsoft.com/powershell/azure/active-directory/install-adv2?view=azureadps-2.0#installing-the-azure-ad-module)
+](/powershell/azure/active-directory/install-adv2?view=azureadps-2.0#installing-the-azure-ad-module)
 
 ### Invitations
 If you have been invited to join Partner Center account, you need to accept the invitation before you can access Collaborate portal. If you see an error message similar to shown below, it means that you have two accounts with Microsoft using the same email address. 
@@ -195,4 +195,3 @@ The exact path can be determined by the following steps:
 
 6. Delete content of the folder
 7. Restart the application
-


### PR DESCRIPTION
This PR is the result of running a Link Repair script on the included content. This script is primarily being run to cleanup links to function correctly in Air Gapped Clouds (AGC). Here's a breakdown of what the script that generated the changes in this PR fixes:

- docs.microsoft.com Fully Qualified Domain Name (FQDN) Links to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not
- azure.microsoft.com/documentation/articles that reflect to Docs to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not
- All known flavors of MSDN/TechNet domains (we know of 8 or 9 now) that reflect to Docs to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not
  - This also includes cleanup of the appended query string for MSDN (redirectedfrom=MSDN).
- Fixes articles that are redirected in `.openpublishing.redirection.json` and updates the link to the current final location (this has a lot of customer usability fixes).

Please note the [Contributor Guide: Links](https://review.docs.microsoft.com/en-us/help/contribute/links-how-to?branch=master) has been updated with the following link-type preference order:

```
By order of preference, links hosted on Docs should be Relative if they are in the same repository and docset. If they are in a different docset, even if in the same repository, they should be Site Relative. Links to content hosted on Docs shouldn't use a complete URL, otherwise known as Fully Qualified Domain Names (FQDN). Using a complete URL from Docs to other content on Docs will cause that link to be non-functional in air-gap environments.
```