### PR TITLE
Linkfix: Collaborate (2021-08)

### DIFF
--- a/MicrosoftCollaboratePortal/feedback-items-overview.md
+++ b/MicrosoftCollaboratePortal/feedback-items-overview.md
@@ -27,7 +27,7 @@ In the MS Collaborate portal, each feedback work item is associated with a singl
 
 ## Legal Agreement 
 
-When you onboard to MS Collaborate, you accept the terms of use covering the feedback for the engagements you belong to. You can always review default terms here:  MS Collaborate [Terms of Use](https://go.microsoft.com/fwlink/?linkid=849107).
+When you onboard to MS Collaborate, you accept the terms of use covering the feedback for the engagements you belong to. You can always review default terms here:  MS Collaborate [Terms of Use](./terms-of-use.md).
 
 In collaboration engagements, a legal agreement must exist between the parties in order for them to collaborate. You may be asked to accept a legal agreement or terms of use before you access the engagement for the first time.  As a member of the engagement, you will be able to see the other organizations participating in the collaboration. Users can assign the bug to a specific organization to indicate the “partner on point.”  However, users will only see the names of other users in their organization.  Other organizations will not have access to the users list.
 
@@ -35,4 +35,4 @@ In collaboration engagements, a legal agreement must exist between the parties i
 
 The **Universal ID** is an ID provided by the MS Collaborate feedback system and is shared with all users who have access to the work item. This ID is the identifier within the MS Collaborate system and is not the specific identifier of any feature team engineering systems. This new **Universal ID** facilitates multi-party collaborations so there is one common identifier used by all parties.
 
-Your engagement owner may decide to also include additional fields showing the specific ID in the engineering system (for example, a VSTS ID). 
+Your engagement owner may decide to also include additional fields showing the specific ID in the engineering system (for example, a VSTS ID).

--- a/MicrosoftCollaboratePortal/index.yml
+++ b/MicrosoftCollaboratePortal/index.yml
@@ -23,18 +23,18 @@ landingContent:
       - linkListType: overview
         links:
           - text: Introduction
-            url: /collaborate/intro-to-mscollaborate
+            url: ./intro-to-mscollaborate.md
       - linkListType: how-to-guide
         links:
           - text: Registration
-            url: /collaborate/registration
+            url: ./registration.md
           - text: Access Management
-            url: /collaborate/managing-org-users
+            url: ./managing-org-users.md
           - text: Programs and Engagements
-            url: /collaborate/programs
+            url: ./programs.md
           - text: Package downloads
-            url: /collaborate/package-downloads
+            url: ./package-downloads.md
       - linkListType: reference
         links:
           - text: Feedback
-            url: /collaborate/feedback-items
+            url: ./feedback-items.md


### PR DESCRIPTION
This PR is the result of running a Link Repair script on the included content. This script is primarily being run to clean up links to function correctly in Air Gapped Clouds (AGC). Here's a breakdown of what the script that generated the changes in this PR fixes:

- docs.microsoft.com Fully Qualified Domain Name (FQDN) Links to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not
- azure.microsoft.com/documentation/articles that reflect to Docs to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not
- All known flavors of MSDN/TechNet domains (we know of 8 or 9 now) that reflect to Docs to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not
  - This also includes cleanup of the appended query string for MSDN (redirectedfrom=MSDN).
- Fixes articles that are redirected in `.openpublishing.redirection.json` and updates the link to the current final location (this has a lot of customer usability fixes).

Please note the [Contributor Guide: Links](https://review.docs.microsoft.com/en-us/help/contribute/links-how-to?branch=master) has been updated with the following link-type preference order:

```
By order of preference, links hosted on Docs should be Relative if they are in the same repository and docset. If they are in a different docset, even if in the same repository, they should be Site Relative. Links to content hosted on Docs shouldn't use a complete URL, otherwise known as Fully Qualified Domain Names (FQDN). Using a complete URL from Docs to other content on Docs will cause that link to be non-functional in air-gap environments.
```
