### PR TITLE
LinkFix MicrosoftCollaboratePortal (2021-10)

### DIFF
--- a/MicrosoftCollaboratePortal/CONTRIBUTING.md
+++ b/MicrosoftCollaboratePortal/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Thank you for your interest in our documentation. We appreciate your feedback, e
 > [!IMPORTANT]
 > All repositories that publish to docs.microsoft.com have adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any questions or comments.<br> 
 > 
-> Minor corrections or clarifications to documentation and code examples in public repositories are covered by the [docs.microsoft.com Terms of Use](https://docs.microsoft.com/legal/termsofuse). New or significant changes will generate a comment in the pull request asking you to submit an online Contribution License Agreement (CLA) if you are not an employee of Microsoft. We need you to complete the online form before we can accept your pull request.
+> Minor corrections or clarifications to documentation and code examples in public repositories are covered by the [docs.microsoft.com Terms of Use](/legal/termsofuse). New or significant changes will generate a comment in the pull request asking you to submit an online Contribution License Agreement (CLA) if you are not an employee of Microsoft. We need you to complete the online form before we can accept your pull request.
 
 ## How to make a change
 
@@ -26,13 +26,13 @@ Thank you for your interest in our documentation. We appreciate your feedback, e
 | 5. Click Preview changes to verify the formatting looks as expected. | ![Preview changes](images/edit-in-github.png)|
 | 6. When you're done, scroll to the bottom of the page and click "Propose file change", you will be presented with a "Comparing changes" page, allowing you to verify your changes. Then click the "Create pull request" button to submit your changes. At this point you are finished! | ![Propose a change](images/propose.jpg)|
 
-After you submit changes (via a pull request), they will be reviewed by a member of the documentation team. If your request is accepted, updates are published to [https://docs.microsoft.com/collaborate](https://docs.microsoft.com/collaborate).
+After you submit changes (via a pull request), they will be reviewed by a member of the documentation team. If your request is accepted, updates are published to [https://docs.microsoft.com/collaborate](/collaborate).
 
 *For internal review only, you can see your changes at [https://review.docs.microsoft.com/collaborateportal](https://review.docs.microsoft.com/en-us/collaborate/?branch=master).
 
 ## Working with Branches
 
-The [MS Collaborate GitHub repository](https://github.com/MicrosoftDocs/MicrosoftCollaboratePortal) utilizes two main parent branches: [Master](https://github.com/MicrosoftDocs/MicrosoftCollaboratePortal/tree/master), this content can be reviewed on the [staging site](https://review.docs.microsoft.com/collaborate), and [Live](https://github.com/MicrosoftDocs/MicrosoftCollaboratePortal/tree/live), for content appearing on the [live site](https://docs.microsoft.com/collaborate). 
+The [MS Collaborate GitHub repository](https://github.com/MicrosoftDocs/MicrosoftCollaboratePortal) utilizes two main parent branches: [Master](https://github.com/MicrosoftDocs/MicrosoftCollaboratePortal/tree/master), this content can be reviewed on the [staging site](https://review.docs.microsoft.com/collaborate), and [Live](https://github.com/MicrosoftDocs/MicrosoftCollaboratePortal/tree/live), for content appearing on the [live site](/collaborate). 
 
 When making contributions, please submit your Pull Request (PR) to the **Master** branch. This branch can be viewed on the staging site and should only contain contributions that are ready to be published live. You may also create and submit a branch with your own unique branch name which can be selected and viewed in the staging site. (The **Live** branch is only allowed for use by the content administrators.)
 

--- a/MicrosoftCollaboratePortal/feedback-items-overview.md
+++ b/MicrosoftCollaboratePortal/feedback-items-overview.md
@@ -27,7 +27,7 @@ In the MS Collaborate portal, each feedback work item is associated with a singl
 
 ## Legal Agreement 
 
-When you onboard to MS Collaborate, you accept the terms of use covering the feedback for the engagements you belong to. You can always review default terms here:  MS Collaborate [Terms of Use](https://go.microsoft.com/fwlink/?linkid=849107).
+When you onboard to MS Collaborate, you accept the terms of use covering the feedback for the engagements you belong to. You can always review default terms here:  MS Collaborate [Terms of Use](/collaborate/terms-of-use).
 
 In collaboration engagements, a legal agreement must exist between the parties in order for them to collaborate. You may be asked to accept a legal agreement or terms of use before you access the engagement for the first time.  As a member of the engagement, you will be able to see the other organizations participating in the collaboration. Users can assign the bug to a specific organization to indicate the “partner on point.”  However, users will only see the names of other users in their organization.  Other organizations will not have access to the users list.
 
@@ -35,4 +35,4 @@ In collaboration engagements, a legal agreement must exist between the parties i
 
 The **Universal ID** is an ID provided by the MS Collaborate feedback system and is shared with all users who have access to the work item. This ID is the identifier within the MS Collaborate system and is not the specific identifier of any feature team engineering systems. This new **Universal ID** facilitates multi-party collaborations so there is one common identifier used by all parties.
 
-Your engagement owner may decide to also include additional fields showing the specific ID in the engineering system (for example, a VSTS ID). 
+Your engagement owner may decide to also include additional fields showing the specific ID in the engineering system (for example, a VSTS ID).

--- a/MicrosoftCollaboratePortal/feedback-items-remove-personal-data.md
+++ b/MicrosoftCollaboratePortal/feedback-items-remove-personal-data.md
@@ -42,4 +42,4 @@ More information on GDPR is available at [Microsoft.com/GDPR](https://Microsoft.
 ## How to leave an organization as a guest user
 
 A user, who previously accepted **invitation** from an organization to partcipate in Collaborate, can decide to leave organization at any time if access is no longer needed. A user can leave an organization on their own, without having to contact an administrator.
-See [Leave an Organization](https://docs.microsoft.com/azure/active-directory/b2b/leave-the-organization#leave-an-organization) for detailed instructions.
+See [Leave an Organization](/azure/active-directory/b2b/leave-the-organization#leave-an-organization) for detailed instructions.

--- a/MicrosoftCollaboratePortal/feedback-items.md
+++ b/MicrosoftCollaboratePortal/feedback-items.md
@@ -28,7 +28,7 @@ In the MS Collaborate portal, each feedback work item is associated with a singl
 
 ## Legal Agreement 
 
-When you onboard to MS Collaborate, you accept the terms of use covering the feedback for the engagements you belong to. You can always review default terms here:  MS Collaborate [Terms of Use](https://go.microsoft.com/fwlink/?linkid=849107).
+When you onboard to MS Collaborate, you accept the terms of use covering the feedback for the engagements you belong to. You can always review default terms here:  MS Collaborate [Terms of Use](/collaborate/terms-of-use).
 
 In collaboration engagements, a legal agreement must exist between the parties in order for them to collaborate. You may be asked to accept a legal agreement or terms of use before you access the engagement for the first time.  As a member of the engagement, you will be able to see the other organizations participating in the collaboration. Users can assign the bug to a specific organization to indicate the “partner on point.”  However, users will only see the names of other users in their organization.  Other organizations will not have access to the users list.
 
@@ -36,4 +36,4 @@ In collaboration engagements, a legal agreement must exist between the parties i
 
 The Universal Partner ID is an ID provided by the MS Collaborate feedback system and is shared with all users who have access to the work item. This ID is the ID within the MS Collaborate system and is not the specific ID of any feature team engineering system. This new universal ID facilitates multi-party collaborations so there is one common ID used by all parties.
 
-> Engagement owner(s) may decide to also include additional fields showing the specific ID in the engineering system (for example, a VSTS ID). 
+> Engagement owner(s) may decide to also include additional fields showing the specific ID in the engineering system (for example, a VSTS ID).

--- a/MicrosoftCollaboratePortal/intro-to-mscollaborate.md
+++ b/MicrosoftCollaboratePortal/intro-to-mscollaborate.md
@@ -43,7 +43,7 @@ Engagements are similar to a virtual security group, allowing engagement owners 
 - collaboration between multiple named organizations (e.g., Microsoft team 1 users, company A users, and company B users), and
 - collaboration with users from any organizations.
 
-Each engagement is associated with either the default MS Collaborate [Terms of Use](https://go.microsoft.com/fwlink/?linkid=849107) or an appropriate custom legal agreement between the parties in the engagement. Participant users should visit the engagement page and see the description and agreement that applies to each specific engagement.  For more information about seeing the legal agreement for an engagement, see [How to view your Engagements](view-engagements.md).
+Each engagement is associated with either the default MS Collaborate [Terms of Use](/collaborate/terms-of-use) or an appropriate custom legal agreement between the parties in the engagement. Participant users should visit the engagement page and see the description and agreement that applies to each specific engagement.  For more information about seeing the legal agreement for an engagement, see [How to view your Engagements](view-engagements.md).
 
 Engagement owners are Microsoft users who manage the engagement in MS Collaborate.  Users with Engagement Owner permissions can: 
 - create new collaborations in the system as a named engagement that will map content or feedback to users, 
@@ -124,4 +124,3 @@ When migrating from MS Connect to MS Collaborate, it is important to understand 
 - Program and engagement names are visible to all users.  Engagements with defined organiations or companies clearly identify the organizations who have permissions for the engagement on the engagement page.  The legal agreement for the engagement is also available to all users who are members of the engagement.
 
 When migrating from the older system to the new Partner Center-based MS Collaborate, the biggest change is migrating user accounts to Partner Center.  Partner Center identifies a "Partner Center Admin" who is responsible for managing the Partner Center accounts for the company.  You will need to know who your admin is and whether your company uses Active Directory or not.  
-   

--- a/MicrosoftCollaboratePortal/managing-org-users.md
+++ b/MicrosoftCollaboratePortal/managing-org-users.md
@@ -123,7 +123,7 @@ Only *Engagement Owners* can add *Power Users* for an organization. Reach out to
 An organization's *Power Users* can only search for users within their own organization's Partner Center account. 
 
 If a user does not appear in search results:
-- verify if they are added to the organization’s account in Partner Center. If not, work with the **Administrator** of your organization account to add missing users. See [Add users to your Partner Center account](https://docs.microsoft.com/windows/uwp/publish/add-users-groups-and-azure-ad-applications#add-users-to-your-dev-center-account) article for the detailed instructions.
+- verify if they are added to the organization’s account in Partner Center. If not, work with the **Administrator** of your organization account to add missing users. See [Add users to your Partner Center account](/windows/uwp/publish/add-users-groups-and-azure-ad-applications#add-users-to-your-dev-center-account) article for the detailed instructions.
 - It is possible that the organization has more than one Partner Center organization account (seller ID) in Partner Center. Verify that correct organization is used. If incorrect organization is used, reach out to your Microsoft contact.
 	
 ### How to export list of participants to a file
@@ -143,7 +143,3 @@ If a user does not appear in search results:
 3. Type name of the engagement you want to copy users from and click **Search** button.
 
 4. Select users from the list and click **Add Users** button.
-
-
-
-

--- a/MicrosoftCollaboratePortal/registration.md
+++ b/MicrosoftCollaboratePortal/registration.md
@@ -50,7 +50,7 @@ Microsoft Collaborate program is offered through Partner Center and requires reg
 
    When you register as a Company, you'll also need to enter the name, email address, and phone number of the person who will approve your Company's account.
 
-9. Review your account info and confirm that everything is correct. Then, read and accept the terms and conditions of the [Collaborate Agreement](https://go.microsoft.com/fwlink/?linkid=849107). Check the box to indicate you have read and accepted these terms.
+9. Review your account info and confirm that everything is correct. Then, read and accept the terms and conditions of the [Collaborate Agreement](/collaborate/terms-of-use). Check the box to indicate you have read and accepted these terms.
 
 10. Click **Finish** to confirm your registration.  
 

--- a/MicrosoftCollaboratePortal/support.md
+++ b/MicrosoftCollaboratePortal/support.md
@@ -11,9 +11,9 @@ keywords: support, troubleshooting
 This page provides instructions on how to get support with Microsoft Collaborate.
 
 ## Support Options
-1. If you are not sure how to do something in Microsoft Collaborate, review the [Documentation and Guidance](https://docs.microsoft.com/collaborate/) for the area you have questions about.
+1. If you are not sure how to do something in Microsoft Collaborate, review the [Documentation and Guidance](/collaborate/) for the area you have questions about.
 2. If your question or issue is related to a specific program or engagement, check their support options first. This information is available on the program and engagement overview pages respectively.
-3. If something is not working the way you expect, check the [Troubleshooting Guides](https://docs.microsoft.com/collaborate/troubleshooting) to see if your issue is described.
+3. If something is not working the way you expect, check the [Troubleshooting Guides](/collaborate/troubleshooting) to see if your issue is described.
 4. If none of the above answers your question or resolves your issue, contact [Customer Support](https://support.microsoft.com/supportrequestform/83cdfd8d-c24a-fbe4-fb2a-3fead30613a9). 
 
 ## Customer Support
@@ -37,5 +37,4 @@ This page provides instructions on how to get support with Microsoft Collaborate
  
 <br>
 
-![Customer Support](images/customer-support.png) 
-
+![Customer Support](images/customer-support.png)

--- a/MicrosoftCollaboratePortal/troubleshooting.md
+++ b/MicrosoftCollaboratePortal/troubleshooting.md
@@ -73,7 +73,7 @@ The workaround is to rename your personal MSA account. See [this article](https:
 The error indicates that a user is signed in with a work account (AAD) that does not have administrator privileges. 
 
 #### Fixes/Workarounds
-Follow the [instructions](https://docs.microsoft.com/collaborate/registration) to register using Microsoft Account.
+Follow the [instructions](/collaborate/registration) to register using Microsoft Account.
 
 #### How to find Global Administrator for your Organization
 Finding **Global Administrator** can be be a difficult task, especially if organization is big and offices are located in multiple countries. 
@@ -93,8 +93,8 @@ Finding **Global Administrator** can be be a difficult task, especially if organ
 ![Roles and Administrators](images/aad-global-admin.png)
 
 Check out these articles to learn more about **Global Administrator** role.
-* [Understanding Azure identity solutions](https://docs.microsoft.com/azure/active-directory/fundamentals/understand-azure-identity-solutions#terms-to-know)
-* [View members and descriptions of administrator roles in Azure Active Directory](https://docs.microsoft.com/azure/active-directory/users-groups-roles/directory-manage-roles-portal)
+* [Understanding Azure identity solutions](/azure/active-directory/fundamentals/understand-azure-identity-solutions#terms-to-know)
+* [View members and descriptions of administrator roles in Azure Active Directory](/azure/active-directory/users-groups-roles/directory-manage-roles-portal)
 
 ##### Using PowerShell
 
@@ -117,9 +117,9 @@ Check out these articles to learn more about **Global Administrator** role.
 ```
 
 Check out these articles to learn more about **PowerShell** and **Azure AD Module**.
-* [Installing Windows PowerShell](https://docs.microsoft.com/powershell/scripting/setup/installing-windows-powershell?view=powershell-6)
+* [Installing Windows PowerShell](/powershell/scripting/setup/installing-windows-powershell?view=powershell-6)
 * [Installing the Azure AD Module
-](https://docs.microsoft.com/powershell/azure/active-directory/install-adv2?view=azureadps-2.0#installing-the-azure-ad-module)
+](/powershell/azure/active-directory/install-adv2?view=azureadps-2.0#installing-the-azure-ad-module)
 
 ### Invitations
 If you have been invited to join Partner Center account, you need to accept the invitation before you can access Collaborate portal. If you see an error message similar to shown below, it means that you have two accounts with Microsoft using the same email address. 
@@ -195,4 +195,3 @@ The exact path can be determined by the following steps:
 
 6. Delete content of the folder
 7. Restart the application
-


### PR DESCRIPTION
This PR is the result of running a Link Repair script on the included content. This script is primarily being run to clean up links to function correctly in Air Gapped Clouds (AGC). Here's a breakdown of what the script that generated the changes in this PR fixes: 

 

- docs.microsoft.com Fully Qualified Domain Name (FQDN) Links to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not 

- azure.microsoft.com/documentation/articles that reflect to Docs to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not 

- All known flavors of MSDN/TechNet domains (we know of 8 or 9 now) that reflect to Docs to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not 

  - This also includes cleanup of the appended query string for MSDN (redirectedfrom=MSDN). 

- Fixes articles that are redirected in `.openpublishing.redirection.json` and updates the link to the current final location (this has a lot of customer usability fixes). 

 

Please note the [Contributor Guide: Links](https://review.docs.microsoft.com/en-us/help/contribute/links-how-to?branch=master) has been updated with the following link-type preference order: 

 

``` 

By order of preference, links hosted on Docs should be Relative if they are in the same repository and docset. If they are in a different docset, even if in the same repository, they should be Site Relative. Links to content hosted on Docs shouldn't use a complete URL, otherwise known as Fully Qualified Domain Names (FQDN). Using a complete URL from Docs to other content on Docs will cause that link to be non-functional in air-gap environments. 

``` 