### PR TITLE
[BrokenLinksH2] fixing broken links

### DIFF
--- a/MicrosoftCollaboratePortal/connect-redirect.md
+++ b/MicrosoftCollaboratePortal/connect-redirect.md
@@ -30,7 +30,6 @@ Effective January 1, 2018, the community feedback feature of the Microsoft Conne
 
 ### System Center Configuration Manager and Microsoft Intune (Connect Site ID 892)
 
-- If you have a feature request for Configuration Manager or Intune, UserVoice is still the best place for feature requests: https://configurationmanager.uservoice.com and http://microsoftintune.uservoice.com. 
 - If you want to file a bug against Configuration Manager, please use the Windows Feedback Hub, which is built into the Windows 10 operating system. For more information, see https://aka.ms/configmgrfeedback. You can track the status of new bugs filed in Feedback Hub, but not bugs previously filed under Connect; all bugs filed under Connect are still accessible by the product team. 
 - If you think you’ve found a bug with Intune, please open a support case. For more information, see https://aka.ms/intunesupport.
 - If you are part of the Customer Connection Program and are trying to access content from the Configuration Manager or Intune Advisors calls, please contact your Customer Connection Program contact to get access to the new TechCommunity. 
@@ -40,9 +39,8 @@ Effective January 1, 2018, the community feedback feature of the Microsoft Conne
 ### Dynamics AX Feedback (Connect Site ID 13211)
 
 Dynamics 365 for Finance and Operations, Enterprise Edition team has made the downloads for the latest versions of Dynamics 365 for Finance and Operations available via the following links:
-- Dynamics 365 for Finance and Operations, Enterprise edition 7.3 with Platform update 12:  https://aka.ms/finandops73pu12
-- Dynamics 365 for Finance and Operations, Enterprise edition July 2017 (7.2) with Platform update 12:
-https://aka.ms/finandops72pu12
+- Dynamics 365 for Finance and Operations, Enterprise edition 7.3 with Platform update 12
+- Dynamics 365 for Finance and Operations, Enterprise edition July 2017 (7.2) with Platform update 12
 
 For any additional questions or queries regarding Preview programs or availability or prior version download VHD’s please contact:  daxcf@microsoft.com
 


### PR DESCRIPTION
**Global effort to fix broken links**

@mimcco

The Content & Learning team is fixing broken links on docs.microsoft.com for the rest of H2. This effort will eliminate potential accessibility, security, and usability issues. This PR includes only link fixes and does not change other content. I’d very much appreciate your timely review and feedback on the link changes I’ve suggested. Thanks!