### PR TITLE
[BrokenLinksH2] fixing broken links

### DIFF
--- a/MicrosoftCollaboratePortal/support.md
+++ b/MicrosoftCollaboratePortal/support.md
@@ -13,8 +13,7 @@ This page provides instructions on how to get support with Microsoft Collaborate
 ## Support Options
 1. If you are not sure how to do something in Microsoft Collaborate, review the [Documentation and Guidance](/collaborate/) for the area you have questions about.
 2. If your question or issue is related to a specific program or engagement, check their support options first. This information is available on the program and engagement overview pages respectively.
-3. If something is not working the way you expect, check the [Troubleshooting Guides](/collaborate/troubleshooting) to see if your issue is described.
-4. If none of the above answers your question or resolves your issue, contact [Customer Support](https://support.microsoft.com/supportrequestform/83cdfd8d-c24a-fbe4-fb2a-3fead30613a9). 
+3. If something is not working the way you expect, check the [Troubleshooting Guides](/collaborate/troubleshooting) to see if your issue is described. 
 
 ## Customer Support
   * Navigate to https://aka.ms/dcsupport.


### PR DESCRIPTION
**Global effort to fix broken links**

@mimcco

The Content & Learning team is fixing broken links on docs.microsoft.com for the rest of H2. This effort will eliminate potential accessibility, security, and usability issues. This PR includes only link fixes and does not change other content. I’d very much appreciate your timely review and feedback on the link changes I’ve suggested. Thanks!