### PR TITLE
[BrokenLinksH2] fixing broken links

### DIFF
--- a/MicrosoftCollaboratePortal/troubleshooting.md
+++ b/MicrosoftCollaboratePortal/troubleshooting.md
@@ -132,7 +132,7 @@ Check out these articles to learn more about **Global Administrator** role.
 
 Check out these articles to learn more about **PowerShell** and **Azure AD Module**.
 
-- [Installing Windows PowerShell](/powershell/scripting/setup/installing-windows-powershell)
+- [Installing Windows PowerShell](/powershell/scripting/windows-powershell/install/installing-windows-powershell)
 - [Installing the Azure AD Module](/powershell/azure/active-directory/install-adv2)
 
 ### Invitations


### PR DESCRIPTION
**Global effort to fix broken links**

@LinChristie

The Content & Learning team is fixing broken links on docs.microsoft.com for the rest of H2. This effort will eliminate potential accessibility, security, and usability issues. This PR includes only link fixes and does not change other content. I’d very much appreciate your timely review and feedback on the link changes I’ve suggested. Thanks!